### PR TITLE
Running the post content through wpautop

### DIFF
--- a/class-wp-front-end-editor.php
+++ b/class-wp-front-end-editor.php
@@ -175,7 +175,7 @@ class WP_Front_End_Editor {
 		
 		global $post;
 		
-		$content = $post->post_content;
+		$content = wpautop( $post->post_content );
 		$content = str_replace( '<!--nextpage-->' , esc_html( '<!--nextpage-->' ) , $content );
 		$content = '<div id="fee-edit-content-' . $post->ID . '" class="contenteditable">' . $content . '</div>';
 			


### PR DESCRIPTION
Running the post content through wpautop so that we keep the line breaks in sync between the frontend editor and the wp-admin editor.
