### PR TITLE
Update class-wp-front-end-editor.php

### DIFF
--- a/class-wp-front-end-editor.php
+++ b/class-wp-front-end-editor.php
@@ -115,7 +115,10 @@ class WP_Front_End_Editor {
 	public function get_edit_post_link( $link, $id, $context ) {
 		
 		$post = get_post( $id );
-		
+		$post_type = get_post_type_object( $post->post_type );
+		if( !$post_type->public)
+			return $link;
+			
 		if ( $this->is_edit() )
 			return get_permalink( $id );
 		


### PR DESCRIPTION
Edit Links for non-public CTPs will not use the WP-Front-End-Editor. Fixes #7
