### PR TITLE
Change UI Fades so They Interrupt Animation (Improves Responsiveness)

### DIFF
--- a/js/wp-front-end-editor.js
+++ b/js/wp-front-end-editor.js
@@ -100,18 +100,18 @@
 		var i = null;
 		$('body').mousemove(function() {
 		    clearTimeout(i);
-		    $('#fee-main-bar, #wpadminbar').stop().animate({opacity:1},'slow');
+		    $('#fee-main-bar, #wpadminbar').stop().animate({opacity:1},'slow','linear');
 		    if ( $($mce_toolbar).hasClass('fee-active') ) {
-		    	$($mce_toolbar).stop().animate({opacity:1},'slow');
+		    	$($mce_toolbar).stop().animate({opacity:1},'slow','linear');
 		    }
 		    if ( ! $('#fee-main-bar, #wpadminbar, ' + $mce_toolbar).hasClass('fee-hovering') ) {
 		    	i = setTimeout(function() {
-		    	    $('#fee-main-bar, #wpadminbar, ' + $mce_toolbar).stop().animate({opacity:0},'slow');
+		    	    $('#fee-main-bar, #wpadminbar, ' + $mce_toolbar).stop().animate({opacity:0},'slow','linear');
 		    	}, 3000);
 		    }
 		}).mouseleave(function() {
 		    clearTimeout(i);
-		    $('#fee-main-bar, #wpadminbar, ' + $mce_toolbar).stop().animate({opacity:0},'slow');  
+		    $('#fee-main-bar, #wpadminbar, ' + $mce_toolbar).stop().animate({opacity:0},'slow','linear');  
 		});
 		
 		$('#fee-main-bar, #wpadminbar, ' + $mce_toolbar).mouseenter(function() {
@@ -120,10 +120,11 @@
 		    $('#fee-main-bar, #wpadminbar, ' + $mce_toolbar).removeClass('fee-hovering');
 		});
 		
+		$('.fee-edit-thumbnail-button').animate({opacity:0},0);
 		$('.fee-edit-thumbnail').mouseenter(function() {
-		    $(this).find('.fee-edit-thumbnail-button').stop().animate({opacity:1},'slow');
+		    $(this).find('.fee-edit-thumbnail-button').stop().animate({opacity:1},400,'linear');
 		}).mouseleave(function() {
-		    $(this).find('.fee-edit-thumbnail-button').stop().animate({opacity:0},'slow');  
+		    $(this).find('.fee-edit-thumbnail-button').stop().animate({opacity:0},500,'linear');  
 		});
 		
 		$('#fee-tags, #fee-cats, #fee-link').on('click', function(e) {


### PR DESCRIPTION
The editor fade in/out wasn't responsive enough for me as the **animations were queuing**. This is a quick & simple edit to make.

jQuery can use stop() & animate() to have an element stop its current animation and do the newest animation. Meanwhile fadeIn() & fadeOut() stack into a queue. Use opacity with animate, and you now have a more responsive fadeIn/fadeOut! It doesn't have the elements set to display:none; when hidden, but it appears that isn't needed for these elements. *Do note that using stop() in conjunction with fadeIn/fadeOut causes the resulting opacity to be incorrect among other issues so that's why animate() is used.

I should mention that I didn't replace the #fee-continue fadeOut() as we want that to be set to display:none; in the end (which fadeOut takes care of for us), and there isn't any risk of stacking animations so might as well keep that one as the basic fadeOut.
