### PR TITLE
HTML comments should be visible

### DIFF
--- a/class-wp-front-end-editor.php
+++ b/class-wp-front-end-editor.php
@@ -678,7 +678,7 @@ class WP_Front_End_Editor {
 			$content = wpautop( $content );
 			$content = shortcode_unautop( $content );
 			$content = $this->do_shortcode( $content );
-            $content = preg_replace("/<!--(.*?)-->/s", esc_html( "<!--$1-->" ), $content);
+			$content = preg_replace("/<!--(.*?)-->/s", esc_html( "<!--$1-->" ), $content);
 			$content = '<div class="wp-fee-content-holder"><p class="wp-fee-content-placeholder">&hellip;</p><div id="wp-fee-content-' . $post->ID . '" class="wp-fee-content">' . $content . '</div></div>';
 
 		}


### PR DESCRIPTION
Replace all html comments via preg_replace and revert the replace on save.

see https://github.com/avryl/wp-front-end-editor/issues/30
