### PR TITLE
Bring $post into global scope

### DIFF
--- a/class-fee.php
+++ b/class-fee.php
@@ -85,6 +85,7 @@ class FEE {
 			$message = 4;
 		}
 
+		global $post;
 		$post = get_post( $post_id );
 
 		wp_send_json_success( array(


### PR DESCRIPTION
Many plugins rely on access to the global `$post` object when they parse the content during the `the_content` filter. This PR puts the updated post object into global scope during AJAX updates.