### PR TITLE
Prevent fatal error when `get_sample_permalink()` not present

### DIFF
--- a/class-fee.php
+++ b/class-fee.php
@@ -923,6 +923,8 @@ class FEE {
 		$_post = get_post( $post );
 		$_post->post_status = 'published';
 
+		require_once( ABSPATH . '/wp-admin/includes/post.php' );
+
 		$sample = get_sample_permalink( $_post );
 
 		return $sample[0];


### PR DESCRIPTION
I have found that `get_sample_permalink()` is not always available and that WordPress Front-end Editor throws a fatal error when calling it. This PR solves the problem in the same manner it's solved elsewhere in WordPress Front-end Editor.