### PR TITLE
Prevent from loading on BuddyPress pages (updated)

### DIFF
--- a/src/class-fee.php
+++ b/src/class-fee.php
@@ -734,7 +734,8 @@ class FEE {
 			$post &&
 			post_type_supports( $post->post_type, 'front-end-editor' ) &&
 			current_user_can( 'edit_post', $post->ID ) &&
-			$post->ID !== (int) get_option( 'page_for_posts' )
+			$post->ID !== (int) get_option( 'page_for_posts' ) &&
+			( ! function_exists( 'bp_is_blog_page' ) || function_exists( 'bp_is_blog_page' ) &&  bp_is_blog_page() )
 		) {
 			$supports_fee = true;
 		}


### PR DESCRIPTION
A simple fix to prevent WP FEE from loading on BuddyPress pages. It solves (at least) a couple of issues:

* WordPress Front-end Editor filters the_title, which causes warnings to be shown on Site Tracking page.
* BuddyPress suppresses the "Edit Page" menu item on BP pages, but WP FEE reinstates it

Replaces #207
