### PR TITLE
Make plugin addressable from by others

### DIFF
--- a/src/plugin.php
+++ b/src/plugin.php
@@ -19,4 +19,5 @@ if ( class_exists( 'FEE' ) ) {
 
 require_once( 'class-fee.php' );
 
-new FEE;
+global $wordpress_front_end_editor;
+$wordpress_front_end_editor = new FEE;

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -19,5 +19,5 @@ if ( class_exists( 'FEE' ) ) {
 
 require_once( 'class-fee.php' );
 
-global $wordpress_front_end_editor;
-$wordpress_front_end_editor = new FEE;
+global $wp_front_end_editor;
+$wp_front_end_editor = new FEE;


### PR DESCRIPTION
In [my comment on another thread](https://github.com/iseulde/wp-front-end-editor/issues/74#issuecomment-67035300), I ask:

> I'd like to ask that the plugin loads into a global variable, so that it's hooks can be addressed - it's really complex to address anonymous objects

This PR implements that. As a result, other plugins can control if WordPress Front-end Editor loads without resorting to miscellaneous hacks.

Replaces #205 