### PR TITLE
WordPress 4.3 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "wp": {
     "name": "Front-end Editor",
     "min": "4.1",
-    "max": "4.3",
+    "max": "4.3.1",
     "network": false,
     "textDomain": "wp-front-end-editor",
     "domainPath": "languages"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "wp": {
     "name": "Front-end Editor",
     "min": "4.1",
-    "max": "4.3-alpha",
+    "max": "4.3",
     "network": false,
     "textDomain": "wp-front-end-editor",
     "domainPath": "languages"

--- a/src/js/tinymce.theme.js
+++ b/src/js/tinymce.theme.js
@@ -367,7 +367,7 @@ tinymce.ThemeManager.add( 'fee', function( editor ) {
 			var self = this;
 
 			setTimeout( function() {
-				self._visible && DOM.addClass( self.getEl(), 'mce-inline-toolbar-active' );
+				DOM.addClass( self.getEl(), 'mce-inline-toolbar-active' );
 			}, 100 );
 		} );
 


### PR DESCRIPTION
See #257.

iseulde - ~~The only issue that I've found with WP 4.3 and FEE is since the `'wplink'` TinyMCE plugin received updates in WP 4.3, this broke how FEE saves frontend edits.~~

~~Do you plan on fixing support for `'wplink'`?  If not, perhaps we can remove the `'wplink'` plugin from FEE's TinyMCE plugin list.  I didn't add a commit to remove the plugin since I'm unsure if you wanted to support it or not.~~

**Update:** The floating toolbar does not show up in WP 4.3.  I've added a temporary fix for this in commit 4b74242.  Feel free to ignore that commit if/when you fix this properly.