### PR TITLE
Fix for #266 - Multiple clicks to remove button in floating image toolbar removes too much

### DIFF
--- a/src/js/tinymce.image.js
+++ b/src/js/tinymce.image.js
@@ -432,7 +432,7 @@ tinymce.PluginManager.add( 'feeImage', function( editor ) {
 		if ( node.nodeName === 'DIV' && editor.dom.hasClass( node, 'mceTemp' ) ) {
 			wrap = node;
 		} else if ( node.nodeName === 'IMG' || node.nodeName === 'DT' || node.nodeName === 'A' ) {
-			wrap = editor.dom.getParent( node, 'a' ) || node.element;
+			wrap = editor.dom.getParent( node, 'a' ) || editor.dom.get( node );
 		}
 
 		if ( wrap ) {

--- a/src/js/tinymce.image.js
+++ b/src/js/tinymce.image.js
@@ -432,7 +432,7 @@ tinymce.PluginManager.add( 'feeImage', function( editor ) {
 		if ( node.nodeName === 'DIV' && editor.dom.hasClass( node, 'mceTemp' ) ) {
 			wrap = node;
 		} else if ( node.nodeName === 'IMG' || node.nodeName === 'DT' || node.nodeName === 'A' ) {
-			wrap = editor.dom.getParent( node, 'div.mceTemp' );
+			wrap = editor.dom.getParent( node, 'a' ) || node.element;
 		}
 
 		if ( wrap ) {


### PR DESCRIPTION
This worked with basic image insertion and removal.

Might need more testing with different image use-cases.

See #266.