### PR TITLE
Revisions: add the $post parameter to _wp_post_revision_fields

### DIFF
--- a/class-wp-rest-post-autosave-controller.php
+++ b/class-wp-rest-post-autosave-controller.php
@@ -313,6 +313,8 @@ class WP_REST_Post_Autosave_Controller extends WP_REST_Controller {
 			'post_excerpt' => __( 'Excerpt' ),
 		);
 
+		$post = get_post( get_the_ID(), ARRAY_A );
+
 		/**
 		 * Filter the list of fields saved in post revisions.
 		 *
@@ -323,11 +325,13 @@ class WP_REST_Post_Autosave_Controller extends WP_REST_Controller {
 		 * and 'post_author'.
 		 *
 		 * @since 2.6.0
+		 * @since 4.5.0 The `$post` parameter was added.
 		 *
 		 * @param array $fields List of fields to revision. Contains 'post_title',
 		 *                      'post_content', and 'post_excerpt' by default.
+		 * @param array $post   A post array being processed for insertion as a post revision.
 		 */
-		$fields = apply_filters( '_wp_post_revision_fields', $fields );
+		$fields = apply_filters( '_wp_post_revision_fields', $fields, $post );
 
 		foreach ( $fields as $property => $name ) {
 


### PR DESCRIPTION
An additional $post parameter was added to the filter in core in 4.5:
https://core.trac.wordpress.org/changeset/36659

Adding it to the plugin avoids issues when other plugins make use of the filter.

Reported here:
https://wordpress.org/support/topic/show-warning-on-jetpack-plugin/